### PR TITLE
S3 Sync Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,5 @@ A: The default credentials are:
   
 Q: How do I sync my project files with S3?
   
-A: First, you want to update the script `setup_s3.sh` to match your environment. Then, you want to run `make sync_data_from_s3` to pull all existing data from S3. To push changes up to S3, run `make sync_data_to_s3`. You can perform a push and pull by running `make sync_s3`. Because the sync command's change management is not great, it's recommended that you confer with your teammates before pulling or pushing changes or give files unique or timestamped names.
+A: First, you want to update the script `setup_s3.sh` to match your environment and make sure your project folder is setup as a git repository. Then, you want to run `make sync_data_from_s3` to pull all existing data from S3. To push changes up to S3, run `make sync_data_to_s3`. You can perform a push and pull by running `make sync_s3`. Because the sync command's change management is not great, it's recommended that you confer with your teammates before pulling or pushing changes or give files unique or timestamped names.
 <hr>

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A:
 
 Q: How do I deploy my Shiny App?  
   
-A: Please visit [here](https://advana.atlassian.net/wiki/spaces/AAP/pages/353271925/Shiny+app+deployment+with+Docker) for details.  
+A: Please visit [here](https://massmutual.atlassian.net/wiki/spaces/AAP/pages/427072326/Shiny+app+deployment+with+Docker) for details.  
 
 Q: What are the default credentials for the example Shiny App?  
   

--- a/README.md
+++ b/README.md
@@ -96,14 +96,17 @@ A:
 2. There should be a data folder in there as well as ui.R, server.R, and global.R.
 3. The data should live in the same folder as the app shiny treats it's enclosing folder as it's working directory.
 
-Q: How do I deploy my Shiny App?
+Q: How do I deploy my Shiny App?  
+  
+A: Please visit [here](https://advana.atlassian.net/wiki/spaces/AAP/pages/353271925/Shiny+app+deployment+with+Docker) for details.  
 
-A: Please visit [here](https://advana.atlassian.net/wiki/spaces/AAP/pages/353271925/Shiny+app+deployment+with+Docker) for details.
-
-Q: What are the default credentials for the example Shiny App?
-
-A: The default credentials are:
-    Username: test
-    Password: test
-
+Q: What are the default credentials for the example Shiny App?  
+  
+A: The default credentials are:  
+    Username: test  
+    Password: test  
+  
+Q: How do I sync my project files with S3?
+  
+A: First, you want to update the script `setup_s3.sh` to match your environment. Then, you want to run `make sync_data_from_s3` to pull all existing data from S3. To push changes up to S3 run `make sync_data_to_s3`. You can perform a push and pull by running `make sync_s3`. Because the sync command's change management is not great, it's recommended that you confer with your teammates before pulling or pushing changes or give files unique or timestamped names.
 <hr>

--- a/README.md
+++ b/README.md
@@ -108,5 +108,10 @@ A: The default credentials are:
   
 Q: How do I sync my project files with S3?
   
-A: First, you want to update the script `setup_s3.sh` to match your environment and make sure your project folder is setup as a git repository. Then, you want to run `make sync_data_from_s3` to pull all existing data from S3. To push changes up to S3, run `make sync_data_to_s3`. You can perform a push and pull by running `make sync_s3`. Because the sync command's change management is not great, it's recommended that you confer with your teammates before pulling or pushing changes or give files unique or timestamped names.
+A:  
+  
+1. Update the script `setup_s3.sh` to match your environment and make sure your project folder is setup as a git repository. 
+2. Run `make sync_data_from_s3` to pull all existing data from S3. To push changes up to S3, run `make sync_data_to_s3`. 
+3. You can perform a push and pull by running `make sync_s3`. 
+4. Because the sync command's change management is not great, it's recommended that you confer with your teammates before pulling or pushing changes or give files unique or timestamped names.
 <hr>

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Q: How do I sync my project files with S3?
 A:  
   
 1. Update the script `setup_s3.sh` to match your environment and make sure your project folder is setup as a git repository. 
-2. Run `make sync_data_from_s3` to pull all existing data from S3. To push changes up to S3, run `make sync_data_to_s3`. 
+2. Run `make sync_data_from_s3` to pull any existing data from S3. To push changes up to S3, run `make sync_data_to_s3`. 
 3. You can perform a push and pull by running `make sync_s3`. 
 4. Because the sync command's change management is not great, it's recommended that you confer with your teammates before pulling or pushing changes or give files unique or timestamped names.
 <hr>

--- a/README.md
+++ b/README.md
@@ -108,5 +108,5 @@ A: The default credentials are:
   
 Q: How do I sync my project files with S3?
   
-A: First, you want to update the script `setup_s3.sh` to match your environment. Then, you want to run `make sync_data_from_s3` to pull all existing data from S3. To push changes up to S3 run `make sync_data_to_s3`. You can perform a push and pull by running `make sync_s3`. Because the sync command's change management is not great, it's recommended that you confer with your teammates before pulling or pushing changes or give files unique or timestamped names.
+A: First, you want to update the script `setup_s3.sh` to match your environment. Then, you want to run `make sync_data_from_s3` to pull all existing data from S3. To push changes up to S3, run `make sync_data_to_s3`. You can perform a push and pull by running `make sync_s3`. Because the sync command's change management is not great, it's recommended that you confer with your teammates before pulling or pushing changes or give files unique or timestamped names.
 <hr>

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,7 @@
     "description": "A short description of the project.",
     "open_source_license": ["MIT", "BSD", "Not open source"],
     "aws_profile": "default",
+    "s3_bucket": "mm-cx-de-dataplatform-qa/science/core/$$(basename $$(git remote get-url origin) .git)",
     "include_r_boilerplate": ["true", "false"],
     "include_python_boilerplate": ["true", "false"]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,6 @@
     "author_name": "Your name (or your organization/company/team)",
     "description": "A short description of the project.",
     "open_source_license": ["MIT", "BSD", "Not open source"],
-    "s3_bucket": "[OPTIONAL] your-bucket-for-syncing-data (do not include 's3://')",
     "aws_profile": "default",
     "include_r_boilerplate": ["true", "false"],
     "include_python_boilerplate": ["true", "false"]

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -78,22 +78,24 @@ lint:
 clean:
 	find . -name "*.pyc" -exec rm {} \;
 
-# Example targets to move data to, from AWS
-# ## Upload Data to S3
-# sync_data_to_s3:
-# ifeq (default,$(PROFILE))
-# 	aws s3 sync data/ s3://$(BUCKET)/data/
-# else
-# 	aws s3 sync data/ s3://$(BUCKET)/data/ --profile $(PROFILE)
-# endif
-#
-# ## Download Data from S3
-# sync_data_from_s3:
-# ifeq (default,$(PROFILE))
-# 	aws s3 sync s3://$(BUCKET)/data/ data/
-# else
-# 	aws s3 sync s3://$(BUCKET)/data/ data/ --profile $(PROFILE)
-# endif
+#Targets to sync data to S3
+sync_data_to_s3:
+	. setup_s3.sh
+	aws s3 sync models/ s3://$(BUCKET)/models/
+	aws s3 sync data/ s3://$(BUCKET)/data/
+	aws s3 sync reports/ s3://$(BUCKET)/reports/
+	aws s3 sync references/ s3://$(BUCKET)/references/
+	aws s3 sync docs/ s3://$(BUCKET)/docs/
+
+sync_data_from_s3:
+	. setup_s3.sh
+	aws s3 sync s3://$(BUCKET)/models/ models/
+	aws s3 sync s3://$(BUCKET)/data/ data/ 
+	aws s3 sync s3://$(BUCKET)/reports/ reports/ 
+	aws s3 sync s3://$(BUCKET)/references/ references/ 
+	aws s3 sync s3://$(BUCKET)/docs/ docs/
+	
+sync_s3: sync_data_to_s3 sync_data_from_s3
 
 #################################################################################
 # Self Documenting Commands                                                     #

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -85,15 +85,13 @@ sync_data_to_s3:
 	aws s3 sync data/ s3://$(BUCKET)/data/
 	aws s3 sync reports/ s3://$(BUCKET)/reports/
 	aws s3 sync references/ s3://$(BUCKET)/references/
-	aws s3 sync docs/ s3://$(BUCKET)/docs/
 
 sync_data_from_s3:
 	. setup_s3.sh
 	aws s3 sync s3://$(BUCKET)/models/ models/
 	aws s3 sync s3://$(BUCKET)/data/ data/ 
 	aws s3 sync s3://$(BUCKET)/reports/ reports/ 
-	aws s3 sync s3://$(BUCKET)/references/ references/ 
-	aws s3 sync s3://$(BUCKET)/docs/ docs/
+	aws s3 sync s3://$(BUCKET)/references/ references/
 	
 sync_s3: sync_data_to_s3 sync_data_from_s3
 

--- a/{{cookiecutter.repo_name}}/setup_s3.sh
+++ b/{{cookiecutter.repo_name}}/setup_s3.sh
@@ -9,8 +9,8 @@ cat << EOM > vertica.ini
 host=$vertica_host
 port=$vertica_port
 database=advana
-user=$premium_finance_batch
-password=$premium_finance_pass
+user=$vert_user
+password=$vert_pw
 EOM
 
 #Get aws s3 credentials from Vertica

--- a/{{cookiecutter.repo_name}}/setup_s3.sh
+++ b/{{cookiecutter.repo_name}}/setup_s3.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#Source your vertica credentials
+source .Renviron
+
+#Generate vertica.ini from environment variables
+cat << EOM > vertica.ini
+[DEFAULT]
+host=$vertica_host
+port=$vertica_port
+database=advana
+user=$premium_finance_batch
+password=$premium_finance_pass
+EOM
+
+#Get aws s3 credentials from Vertica
+#Install this tool with the following command: 
+#pip install git+ssh://git@github.com/massmutual/set-aws-credentials
+set-aws-credentials vertica.ini data-scientist
+
+#Source aws-credentials then remove them and vertica.ini
+source ./aws-credentials.sh
+rm aws-credentials.sh vertica.ini

--- a/{{cookiecutter.repo_name}}/setup_s3.sh
+++ b/{{cookiecutter.repo_name}}/setup_s3.sh
@@ -9,8 +9,8 @@ cat << EOM > vertica.ini
 host=$vertica_host
 port=$vertica_port
 database=advana
-user=$vert_user
-password=$vert_pw
+user=$vertica_user
+password=$vertica_password
 EOM
 
 #Get aws s3 credentials from Vertica


### PR DESCRIPTION
Merging in S3 sync capability. 

Users can now run the following to sync projects files that are not tracked in git:
`make sync_data_to_s3`
`make sync_data_from_s3`
`make sync_s3`

The setup_s3.sh file may need to be modified to fit a given projects environment. This will have to be performed by the user after setting up their project.

