### PR TITLE
Updating S3 sync functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ Q: How do I sync my project files with S3?
   
 A:  
   
-1. Update the script `setup_s3.sh` to match your environment and make sure your project folder is setup as a git repository. 
-2. Run `make sync_data_from_s3` to pull any existing data from S3. To push changes up to S3, run `make sync_data_to_s3`. 
-3. You can perform a push and pull by running `make sync_s3`. 
-4. Because the sync command's change management is not great, it's recommended that you confer with your teammates before pulling or pushing changes or give files unique or timestamped names.
+1. Update the script `setup_s3.sh` to match your environment and make sure your project folder is setup as a git repository.
+2. Run `source setup_s3.sh`. This adds the S3 credentials to your environment. Prior to running this command, you will need to install our AWS credentials tool using this command: `pip install git+ssh://git@github.com/massmutual/set-aws-credentials`.
+3. Run `make sync_data_from_s3` to pull any existing data from S3. To push changes up to S3, run `make sync_data_to_s3`. 
+4. You can perform a push and pull by running `make sync_s3`. 
+5. Because the sync command's change management is not great, it's recommended that you confer with your teammates before pulling or pushing changes or give files unique or timestamped names.
 <hr>

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -80,14 +80,12 @@ clean:
 
 #Targets to sync data to S3
 sync_data_to_s3:
-	. setup_s3.sh
 	aws s3 sync models/ s3://$(BUCKET)/models/
 	aws s3 sync data/ s3://$(BUCKET)/data/
 	aws s3 sync reports/ s3://$(BUCKET)/reports/
 	aws s3 sync references/ s3://$(BUCKET)/references/
 
 sync_data_from_s3:
-	. setup_s3.sh
 	aws s3 sync s3://$(BUCKET)/models/ models/
 	aws s3 sync s3://$(BUCKET)/data/ data/ 
 	aws s3 sync s3://$(BUCKET)/reports/ reports/ 

--- a/{{cookiecutter.repo_name}}/setup_s3.sh
+++ b/{{cookiecutter.repo_name}}/setup_s3.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 #Source your vertica credentials
-source .Renviron
+if [ -f .Renviron ]
+  then
+    source .Renviron
+fi
 
 #Generate vertica.ini from environment variables
 cat << EOM > vertica.ini


### PR DESCRIPTION
Allowing syncing without .Renviron and requiring setup_s3.sh to be run outside of the make command prior to sync. 

Makefiles make it hard to source Shell scripts that update the environment. The easiest work around is to have people source the setup_s3.sh file themselves.