### PR TITLE
adding .Renviron to gitignore

### DIFF
--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -77,3 +77,6 @@ target/
 
 # OSX Junk
 .DS_Store
+
+# R environment vars
+.Renviron


### PR DESCRIPTION
.Renviron loads environment vars into R sessions - typically sensitive info